### PR TITLE
remove: < 4.0 aws version constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13"
 
   required_providers {
-    aws        = ">= 3.13, < 4.0"
+    aws        = ">= 3.13"
     helm       = ">= 1.0, < 3.0"
     kubernetes = ">= 1.10.0, < 3.0.0"
   }


### PR DESCRIPTION
this constraint interfere with other terraform-aws-modules modules